### PR TITLE
refactor: migra a GitHub Environments per configurazione per-podcast

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,42 +9,42 @@ permissions:
   contents: read
 
 jobs:
-  publish:
+  pensieriincodice:
     runs-on: ubuntu-latest
-
+    environment: pensieriincodice
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-
-      - name: Create podcasts config
-        env:
-          PODCAST1_RSS_URL: ${{ vars.PODCAST1_RSS_URL }}
-          PODCAST1_TEMPLATE: ${{ vars.PODCAST1_TEMPLATE }}
-          PODCAST2_RSS_URL: ${{ vars.PODCAST2_RSS_URL }}
-          PODCAST2_TEMPLATE: ${{ vars.PODCAST2_TEMPLATE }}
-        run: |
-          python -c "
-          import json, os
-          config = [
-            {'id': 'pensieriincodice', 'name': 'Pensieri in Codice', 'feed_url': os.environ['PODCAST1_RSS_URL'], 'template': os.environ['PODCAST1_TEMPLATE']},
-            {'id': 'goodvibrations', 'name': 'Good Vibrations', 'feed_url': os.environ['PODCAST2_RSS_URL'], 'template': os.environ['PODCAST2_TEMPLATE']},
-          ]
-          print(json.dumps(config, indent=2, ensure_ascii=False))
-          " > podcasts.json
-
-      - name: Run publish script
+      - run: pip install -r requirements.txt
+      - run: python publish.py
         env:
           TELEGRAM_BOT_API_KEY: ${{ secrets.TELEGRAM_BOT_API_KEY }}
-          TELEGRAM_CHAT_ID: ${{ vars.TELEGRAM_CHAT_ID }}
-          LAST_PUBLISHED_URLS: ${{ vars.LAST_PUBLISHED_URLS }}
+          RSS_URL: ${{ vars.RSS_URL }}
+          CHAT_ID: ${{ vars.CHAT_ID }}
+          TEMPLATE: ${{ vars.TEMPLATE }}
+          LAST_PUBLISHED_URL: ${{ vars.LAST_PUBLISHED_URL }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: python publish.py
+          GITHUB_ENVIRONMENT: ${{ github.environment }}
+
+  goodvibrations:
+    runs-on: ubuntu-latest
+    environment: goodvibrations
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: python publish.py
+        env:
+          TELEGRAM_BOT_API_KEY: ${{ secrets.TELEGRAM_BOT_API_KEY }}
+          RSS_URL: ${{ vars.RSS_URL }}
+          CHAT_ID: ${{ vars.CHAT_ID }}
+          TEMPLATE: ${{ vars.TEMPLATE }}
+          LAST_PUBLISHED_URL: ${{ vars.LAST_PUBLISHED_URL }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_ENVIRONMENT: ${{ github.environment }}

--- a/github_state.py
+++ b/github_state.py
@@ -7,18 +7,13 @@ logger = logging.getLogger("github_state")
 
 
 def update_github_variable(variable_name: str, value: str) -> None:
-    """Aggiorna una variabile Actions del repository corrente via GitHub API.
-
-    Richiede GH_TOKEN (fine-grained PAT con 'Variables: read and write')
-    e GITHUB_REPOSITORY (impostato automaticamente da GitHub Actions).
-    Se le variabili non sono disponibili, logga un warning e non fa nulla.
-    """
     token = os.environ.get('GH_TOKEN')
     repo = os.environ.get('GITHUB_REPOSITORY')
+    environment = os.environ.get('GITHUB_ENVIRONMENT')
 
-    if not token or not repo:
+    if not token or not repo or not environment:
         logger.warning(
-            "GH_TOKEN o GITHUB_REPOSITORY non impostati: "
+            "GH_TOKEN, GITHUB_REPOSITORY o GITHUB_ENVIRONMENT non impostati: "
             "lo stato non verrà persistito su GitHub Variables."
         )
         return
@@ -28,15 +23,14 @@ def update_github_variable(variable_name: str, value: str) -> None:
         'Authorization': f'Bearer {token}',
         'X-GitHub-Api-Version': '2022-11-28',
     }
-    url = f"https://api.github.com/repos/{repo}/actions/variables/{variable_name}"
+    base_url = f"https://api.github.com/repos/{repo}/environments/{environment}/variables"
 
-    response = requests.patch(url, headers=headers, json={"name": variable_name, "value": value})
+    response = requests.patch(f"{base_url}/{variable_name}", headers=headers, json={"name": variable_name, "value": value})
     if response.status_code == 204:
         logger.debug(f"Variabile {variable_name} aggiornata.")
         return
 
     if response.status_code == 404:
-        base_url = f"https://api.github.com/repos/{repo}/actions/variables"
         response = requests.post(base_url, headers=headers, json={"name": variable_name, "value": value})
         if response.status_code == 201:
             logger.debug(f"Variabile {variable_name} creata.")

--- a/publish.py
+++ b/publish.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import re
@@ -14,13 +13,6 @@ logger = logging.getLogger("telegram")
 ITUNES_NS = 'http://www.itunes.com/dtds/podcast-1.0.dtd'
 
 
-def load_podcasts_config(config_file: str) -> list:
-    if not os.path.exists(config_file):
-        raise FileNotFoundError(f"File di configurazione non trovato: {config_file}")
-    with open(config_file, 'r') as f:
-        return json.load(f)
-
-
 def fetch_last_episode(feed_url: str) -> dict:
     response = requests.get(feed_url)
     response.raise_for_status()
@@ -33,6 +25,11 @@ def fetch_last_episode(feed_url: str) -> dict:
 
     title = item.findtext('title', '').strip()
     link = item.findtext('link', '').strip()
+
+    if not link:
+        enclosure = item.find('enclosure')
+        if enclosure is not None:
+            link = enclosure.get('url', '').split('?')[0]
 
     if not title or not link:
         raise Exception(f"Titolo o link mancante: {title=} {link=}")
@@ -54,17 +51,8 @@ def escape_markdown_v2(text: str) -> str:
     return re.sub(r'([' + re.escape(escape_chars) + r'])', r'\\\1', text)
 
 
-def load_published_urls() -> dict:
-    raw = os.environ.get('LAST_PUBLISHED_URLS', '{}')
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
-        logger.warning("LAST_PUBLISHED_URLS non è JSON valido, uso dict vuoto.")
-        return {}
-
-
-def is_published(link: str, podcast_id: str, published_urls: dict) -> bool:
-    return published_urls.get(podcast_id) == link
+def is_published(link: str, last_published_url: str) -> bool:
+    return last_published_url == link
 
 
 def publish_to_telegram(episode: dict, api_key: str, chat_id: str, template: str) -> None:
@@ -94,24 +82,17 @@ def publish_to_telegram(episode: dict, api_key: str, chat_id: str, template: str
 
 if __name__ == "__main__":
     api_key = os.environ['TELEGRAM_BOT_API_KEY']
-    chat_id = os.environ['TELEGRAM_CHAT_ID']
+    chat_id = os.environ['CHAT_ID']
+    feed_url = os.environ['RSS_URL']
+    template = os.environ['TEMPLATE']
+    last_published_url = os.environ.get('LAST_PUBLISHED_URL', '')
 
-    podcasts = load_podcasts_config('./podcasts.json')
-    published_urls = load_published_urls()
-    logger.info(f"Trovati {len(podcasts)} podcast da processare")
+    episode = fetch_last_episode(feed_url)
+    logger.info(f"Ultimo episodio: {episode['link']}")
 
-    for podcast in podcasts:
-        logger.info(f"=== {podcast['name']} ===")
-
-        episode = fetch_last_episode(podcast['feed_url'])
-        logger.info(f"Ultimo episodio: {episode['link']}")
-
-        if is_published(episode['link'], podcast['id'], published_urls):
-            logger.info("Episodio già pubblicato, skip.")
-            continue
-
-        publish_to_telegram(episode, api_key, chat_id, podcast['template'])
-        published_urls[podcast['id']] = episode['link']
-        update_github_variable('LAST_PUBLISHED_URLS', json.dumps(published_urls))
-
-    logger.info("Tutti i podcast processati.")
+    if is_published(episode['link'], last_published_url):
+        logger.info("Episodio già pubblicato, skip.")
+    else:
+        publish_to_telegram(episode, api_key, chat_id, template)
+        update_github_variable('LAST_PUBLISHED_URL', episode['link'])
+        logger.info("Variabile di stato aggiornata.")

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,6 +1,4 @@
-import json
 import os
-import tempfile
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,8 +7,6 @@ from publish import (
     escape_markdown_v2,
     fetch_last_episode,
     is_published,
-    load_podcasts_config,
-    load_published_urls,
     publish_to_telegram,
 )
 
@@ -37,6 +33,16 @@ SAMPLE_RSS_NO_KEYWORDS = b"""<?xml version="1.0"?>
   </channel>
 </rss>"""
 
+SAMPLE_RSS_NO_LINK = b"""<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Episodio senza link</title>
+      <enclosure url="https://cdn.example.com/ep42.mp3?updated=12345" type="audio/mpeg" length="1000"/>
+    </item>
+  </channel>
+</rss>"""
+
 
 class TestEscapeMarkdownV2:
     def test_escapes_special_chars(self):
@@ -55,49 +61,15 @@ class TestEscapeMarkdownV2:
         assert escape_markdown_v2("") == ""
 
 
-class TestLoadPublishedUrls:
-    def test_returns_dict_from_env(self):
-        data = {"pod1": "https://example.com/ep1"}
-        with patch.dict(os.environ, {"LAST_PUBLISHED_URLS": json.dumps(data)}):
-            result = load_published_urls()
-        assert result == data
-
-    def test_returns_empty_dict_when_env_missing(self):
-        env = {k: v for k, v in os.environ.items() if k != "LAST_PUBLISHED_URLS"}
-        with patch.dict(os.environ, env, clear=True):
-            result = load_published_urls()
-        assert result == {}
-
-    def test_returns_empty_dict_on_invalid_json(self):
-        with patch.dict(os.environ, {"LAST_PUBLISHED_URLS": "not-json"}):
-            result = load_published_urls()
-        assert result == {}
-
-
 class TestIsPublished:
     def test_returns_true_when_link_matches(self):
-        urls = {"pod1": "https://example.com/ep42"}
-        assert is_published("https://example.com/ep42", "pod1", urls) is True
+        assert is_published("https://example.com/ep42", "https://example.com/ep42") is True
 
     def test_returns_false_when_link_differs(self):
-        urls = {"pod1": "https://example.com/ep41"}
-        assert is_published("https://example.com/ep42", "pod1", urls) is False
+        assert is_published("https://example.com/ep42", "https://example.com/ep41") is False
 
-    def test_returns_false_when_podcast_missing(self):
-        assert is_published("https://example.com/ep42", "pod1", {}) is False
-
-
-class TestLoadPodcastsConfig:
-    def test_loads_valid_json(self, tmp_path):
-        config = [{"id": "p1", "name": "Podcast 1", "feed_url": "https://example.com/feed"}]
-        config_file = tmp_path / "podcasts.json"
-        config_file.write_text(json.dumps(config))
-        result = load_podcasts_config(str(config_file))
-        assert result == config
-
-    def test_raises_when_file_missing(self, tmp_path):
-        with pytest.raises(FileNotFoundError):
-            load_podcasts_config(str(tmp_path / "missing.json"))
+    def test_returns_false_when_last_url_empty(self):
+        assert is_published("https://example.com/ep42", "") is False
 
 
 class TestFetchLastEpisode:
@@ -118,6 +90,13 @@ class TestFetchLastEpisode:
         with patch("publish.requests.get", return_value=mock_resp):
             episode = fetch_last_episode("https://feed.example.com/rss")
         assert episode["hashtags"] == ""
+
+    def test_fallback_to_enclosure_when_no_link(self):
+        mock_resp = MagicMock()
+        mock_resp.content = SAMPLE_RSS_NO_LINK
+        with patch("publish.requests.get", return_value=mock_resp):
+            episode = fetch_last_episode("https://feed.example.com/rss")
+        assert episode["link"] == "https://cdn.example.com/ep42.mp3"
 
     def test_raises_on_empty_feed(self):
         empty_rss = b"""<?xml version="1.0"?><rss><channel></channel></rss>"""


### PR DESCRIPTION
## Summary

- `publish.py` gestisce ora un singolo podcast per run, leggendo `RSS_URL`, `CHAT_ID`, `TEMPLATE` e `LAST_PUBLISHED_URL` direttamente dall'ambiente; aggiunto fallback all'`enclosure` URL per feed RSS senza tag `<link>` (es. Daily Cogito su Megaphone)
- `github_state.py` aggiorna `LAST_PUBLISHED_URL` nell'environment GitHub corrente invece che come variabile di repo condivisa
- `cron.yml` sostituito con due job indipendenti (`pensieriincodice`, `goodvibrations`), ciascuno con il proprio `environment:`; `dailycogito` predisposto ma non ancora attivato
- Test aggiornati alla nuova interfaccia; aggiunto test per il fallback enclosure

## Test plan

- [x] 14/14 test passati in locale
- [x] Verificare che il workflow parta correttamente su GitHub Actions al prossimo trigger orario
- [x] Controllare che `LAST_PUBLISHED_URL` venga aggiornato nel rispettivo environment dopo la prima run