### PR TITLE
fix: normalize literal \r\n escape sequences in TEMPLATE env var

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -51,6 +51,10 @@ def escape_markdown_v2(text: str) -> str:
     return re.sub(r'([' + re.escape(escape_chars) + r'])', r'\\\1', text)
 
 
+def normalize_template(template: str) -> str:
+    return template.replace('\\r\\n', '\n').replace('\\n', '\n')
+
+
 def is_published(link: str, last_published_url: str) -> bool:
     return last_published_url == link
 
@@ -84,7 +88,7 @@ if __name__ == "__main__":
     api_key = os.environ['TELEGRAM_BOT_API_KEY']
     chat_id = os.environ['CHAT_ID']
     feed_url = os.environ['RSS_URL']
-    template = os.environ['TEMPLATE']
+    template = normalize_template(os.environ['TEMPLATE'])
     last_published_url = os.environ.get('LAST_PUBLISHED_URL', '')
 
     episode = fetch_last_episode(feed_url)

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -7,6 +7,7 @@ from publish import (
     escape_markdown_v2,
     fetch_last_episode,
     is_published,
+    normalize_template,
     publish_to_telegram,
 )
 
@@ -59,6 +60,23 @@ class TestEscapeMarkdownV2:
 
     def test_empty_string(self):
         assert escape_markdown_v2("") == ""
+
+
+class TestNormalizeTemplate:
+    def test_converts_literal_crlf(self):
+        assert normalize_template("a\\r\\nb") == "a\nb"
+
+    def test_converts_literal_lf(self):
+        assert normalize_template("a\\nb") == "a\nb"
+
+    def test_real_newlines_unchanged(self):
+        assert normalize_template("a\nb") == "a\nb"
+
+    def test_multiple_sequences(self):
+        assert normalize_template("a\\r\\nb\\r\\nc") == "a\nb\nc"
+
+    def test_empty_string(self):
+        assert normalize_template("") == ""
 
 
 class TestIsPublished:


### PR DESCRIPTION
## Summary

- GitHub Actions espande le variabili multiriga come sequenze letterali `\r\n` nell'`env:` block
- In Telegram MarkdownV2, `\r` e `\n` letterali vengono interpretati come caratteri escaped e visualizzati come `rn` nel messaggio pubblicato
- Aggiunta funzione `normalize_template()` che converte le sequenze letterali `\r\n` e `\n` in veri newline prima dell'invio

## Test plan

- [x] `TestNormalizeTemplate::test_converts_literal_crlf` — verifica conversione `\r\n` → newline
- [x] `TestNormalizeTemplate::test_converts_literal_lf` — verifica conversione `\n` → newline
- [x] `TestNormalizeTemplate::test_real_newlines_unchanged` — newline reali non vengono alterati
- [x] `TestNormalizeTemplate::test_multiple_sequences` — sequenze multiple gestite correttamente
- [x] Tutti i 19 test passano