### PR TITLE
fix: force link preview via link_preview_options API parameter

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -74,6 +74,7 @@ def publish_to_telegram(episode: dict, api_key: str, chat_id: str, template: str
             'text': content,
             'parse_mode': 'MarkdownV2',
             'disable_notification': True,
+            'link_preview_options': {'url': episode['link']},
         }
     )
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -147,6 +147,7 @@ class TestPublishToTelegram:
         assert payload["chat_id"] == "-100123"
         assert "Test Ep" in payload["text"]
         assert "https://ex.com/ep-1" in payload["text"]
+        assert payload["link_preview_options"] == {"url": "https://ex.com/ep-1"}
 
     def test_link_not_escaped_in_output(self):
         episode = {"title": "Ep", "link": "https://www.spreaker.com/ep-12-test--1", "hashtags": ""}


### PR DESCRIPTION
## Summary

- Quando il template usa il formato `[testo]({link})`, Telegram crea un hyperlink cliccabile ma non genera la preview dell'episodio
- La preview funziona solo con URL in testo plain, non con URL dentro entità markdown
- Aggiunto il parametro `link_preview_options.url` (Bot API 7.0+) per forzare la preview sull'URL dell'episodio indipendentemente dal formato del template

## Test plan

- [x] `test_sends_correct_request` — verifica che `link_preview_options` sia presente nel payload con l'URL corretto
- [x] Tutti i 20 test passano