### PR TITLE
fix: raise on state-save failure, do not escape URL in Telegram message

### DIFF
--- a/github_state.py
+++ b/github_state.py
@@ -12,11 +12,10 @@ def update_github_variable(variable_name: str, value: str) -> None:
     environment = os.environ.get('GITHUB_ENVIRONMENT')
 
     if not token or not repo or not environment:
-        logger.warning(
+        raise RuntimeError(
             "GH_TOKEN, GITHUB_REPOSITORY o GITHUB_ENVIRONMENT non impostati: "
-            "lo stato non verrà persistito su GitHub Variables."
+            "impossibile persistere lo stato su GitHub Variables."
         )
-        return
 
     headers = {
         'Accept': 'application/vnd.github+json',
@@ -27,16 +26,16 @@ def update_github_variable(variable_name: str, value: str) -> None:
 
     response = requests.patch(f"{base_url}/{variable_name}", headers=headers, json={"name": variable_name, "value": value})
     if response.status_code == 204:
-        logger.debug(f"Variabile {variable_name} aggiornata.")
+        logger.info(f"Variabile {variable_name} aggiornata.")
         return
 
     if response.status_code == 404:
         response = requests.post(base_url, headers=headers, json={"name": variable_name, "value": value})
         if response.status_code == 201:
-            logger.debug(f"Variabile {variable_name} creata.")
+            logger.info(f"Variabile {variable_name} creata.")
             return
 
-    logger.warning(
+    raise RuntimeError(
         f"Impossibile aggiornare variabile {variable_name}: "
         f"{response.status_code} {response.text}"
     )

--- a/publish.py
+++ b/publish.py
@@ -62,7 +62,7 @@ def is_published(link: str, last_published_url: str) -> bool:
 def publish_to_telegram(episode: dict, api_key: str, chat_id: str, template: str) -> None:
     content = template \
         .replace('{title}', escape_markdown_v2(episode['title'])) \
-        .replace('{link}', escape_markdown_v2(episode['link'])) \
+        .replace('{link}', episode['link']) \
         .replace('{hashtags}', escape_markdown_v2(episode['hashtags']))
 
     logger.info(f"Pubblicazione su Telegram: {content[:80]}...")

--- a/tests/test_github_state.py
+++ b/tests/test_github_state.py
@@ -1,0 +1,63 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from github_state import update_github_variable
+
+ENV = {
+    'GH_TOKEN': 'tok',
+    'GITHUB_REPOSITORY': 'owner/repo',
+    'GITHUB_ENVIRONMENT': 'goodvibrations',
+}
+
+
+class TestUpdateGithubVariable:
+    def test_patch_success(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 204
+        with patch.dict(os.environ, ENV):
+            with patch('github_state.requests.patch', return_value=mock_resp):
+                update_github_variable('LAST_PUBLISHED_URL', 'https://example.com/ep1')
+
+    def test_creates_variable_when_not_found(self):
+        patch_resp = MagicMock()
+        patch_resp.status_code = 404
+        post_resp = MagicMock()
+        post_resp.status_code = 201
+        with patch.dict(os.environ, ENV):
+            with patch('github_state.requests.patch', return_value=patch_resp):
+                with patch('github_state.requests.post', return_value=post_resp):
+                    update_github_variable('LAST_PUBLISHED_URL', 'https://example.com/ep1')
+
+    def test_raises_on_api_error(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        mock_resp.text = 'Forbidden'
+        with patch.dict(os.environ, ENV):
+            with patch('github_state.requests.patch', return_value=mock_resp):
+                with pytest.raises(RuntimeError, match='403'):
+                    update_github_variable('LAST_PUBLISHED_URL', 'https://example.com/ep1')
+
+    def test_raises_on_post_error_after_404(self):
+        patch_resp = MagicMock()
+        patch_resp.status_code = 404
+        post_resp = MagicMock()
+        post_resp.status_code = 422
+        post_resp.text = 'Unprocessable'
+        with patch.dict(os.environ, ENV):
+            with patch('github_state.requests.patch', return_value=patch_resp):
+                with patch('github_state.requests.post', return_value=post_resp):
+                    with pytest.raises(RuntimeError, match='422'):
+                        update_github_variable('LAST_PUBLISHED_URL', 'https://example.com/ep1')
+
+    def test_raises_when_env_vars_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(RuntimeError, match='GH_TOKEN'):
+                update_github_variable('LAST_PUBLISHED_URL', 'https://example.com/ep1')
+
+    def test_raises_when_token_missing(self):
+        env = {k: v for k, v in ENV.items() if k != 'GH_TOKEN'}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(RuntimeError, match='GH_TOKEN'):
+                update_github_variable('LAST_PUBLISHED_URL', 'https://example.com/ep1')

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -134,7 +134,7 @@ class TestFetchLastEpisode:
 
 class TestPublishToTelegram:
     def test_sends_correct_request(self):
-        episode = {"title": "Test Ep", "link": "https://ex.com/ep", "hashtags": "#test"}
+        episode = {"title": "Test Ep", "link": "https://ex.com/ep-1", "hashtags": "#test"}
         template = "Nuovo episodio: {title}\n{link}\n{hashtags}"
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"ok": True}
@@ -145,7 +145,18 @@ class TestPublishToTelegram:
         assert "API_KEY" in call_kwargs[0][0]
         payload = call_kwargs[1]["json"]
         assert payload["chat_id"] == "-100123"
-        assert "Test Ep" in payload["text"] or r"Test Ep" in payload["text"]
+        assert "Test Ep" in payload["text"]
+        assert "https://ex.com/ep-1" in payload["text"]
+
+    def test_link_not_escaped_in_output(self):
+        episode = {"title": "Ep", "link": "https://www.spreaker.com/ep-12-test--1", "hashtags": ""}
+        template = "{title}\n{link}"
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"ok": True}
+        with patch("publish.requests.post", return_value=mock_resp) as mock_post:
+            publish_to_telegram(episode, "KEY", "-100", template)
+        text = mock_post.call_args[1]["json"]["text"]
+        assert "https://www.spreaker.com/ep-12-test--1" in text
 
     def test_raises_on_api_error(self):
         episode = {"title": "Test", "link": "https://ex.com/ep", "hashtags": ""}


### PR DESCRIPTION
## Problema

Good Vibrations continuava a ripubblicare lo stesso episodio ad ogni esecuzione del cron.

## Cause radice

### Bug 1 — `update_github_variable` falliva in silenzio (causa principale)

La funzione gestiva solo i codici 204 e 404→201. Per qualsiasi altro errore (403 Forbidden, 422 Unprocessable, timeout di rete, ecc.) loggava soltanto un `WARNING` e ritornava normalmente. Lo script principale poi loggava `"Variabile di stato aggiornata."` indipendentemente dall'esito, rendendo il fallimento invisibile nei log.

Risultato: Telegram riceveva il messaggio correttamente, ma `LAST_PUBLISHED_URL` non veniva mai salvato → ogni run successiva vedeva l'episodio come non pubblicato → loop di ripubblicazione.

**Fix:** `update_github_variable` ora lancia `RuntimeError` in caso di errore API, causando il fallimento esplicito del job GitHub Actions. Il problema diventa visibile e l'operatore può correggere manualmente la variabile di stato.

### Bug 2 — URL escaped nella destinazione del link Markdown (reintrodotto da PR #7)

Il PR #7 (revert) ha rimesso `escape_markdown_v2()` sull'URL dell'episodio. In Telegram MarkdownV2, all'interno della parte `(url)` di un link inline `[testo](url)`, solo `\` e `)` devono essere escaped. Passare `https://www\.spreaker\.com/ep\-42` produce un href con backslash letterali — link rotto.

Il PR #5 aveva ragione: l'URL va passato as-is. Solo titolo e hashtag necessitano di escaping.

**Fix:** Ripristinato `episode['link']` non-escaped in `publish_to_telegram`.

## Modifiche

- `github_state.py`: raise `RuntimeError` invece di `logger.warning` su errori API; `logger.info` invece di `logger.debug` per i successi (visibili nei log a livello INFO)
- `publish.py`: `episode['link']` non-escaped nel testo del messaggio Telegram
- `tests/test_github_state.py`: nuovo file, coverage 100% per `github_state.py` (era 0%)
- `tests/test_publish.py`: ripristinato `test_link_not_escaped_in_output` rimosso dal revert; aggiornato `test_sends_correct_request`

## Test

26 test passano, coverage totale 94%.

## Dopo il merge

Riabilitare il cron nel workflow (decommentare le righe `schedule`) e verificare manualmente il valore di `LAST_PUBLISHED_URL` nell'environment `goodvibrations` su GitHub — se è vuoto o punta a un episodio vecchio, impostarlo manualmente all'URL dell'ultimo episodio già pubblicato.